### PR TITLE
Removed Ultra Widescreen CSS

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -6,8 +6,7 @@
 @custom-media --mobile-only (max-width: 767px);
 @custom-media --tablet-only (min-width: 768px) and (max-width: 959px);
 @custom-media --desktop-only (min-width: 960px) and (max-width: 1151px);
-@custom-media --widescreen-only (min-width: 1152px) and (max-width: 1343px);
-@custom-media --ultra-widescreen-only (min-width: 1344px);
+@custom-media --widescreen-only (min-width: 1152px);
 
 .hide-mobile {
 	display: none ?if media (--mobile-only);
@@ -23,8 +22,4 @@
 
 .hide-widescreen {
 	display: none ?if media (--widescreen-only);
-}
-
-.hide-ultra-widescreen {
-	display: none ?if media (--ultra-widescreen-only);
 }


### PR DESCRIPTION
There is no **ultra-widescreen** in the visibility attributes. Thus, I removed it. We could also add ultra-widescreen to the visibility attributes. However, I'm not sure yet if we should / want to keep it in future projects. If so, I vote to adjust `spacer` and `utils` in a separate update in the future.