### PR TITLE
Removed resize container margin

### DIFF
--- a/src/editor.css
+++ b/src/editor.css
@@ -4,5 +4,9 @@
  */
 
 .wp-block-[prefix]-spacer {
-	margin-bottom: 0;
+
+	&,
+	.block-library-spacer__resize-container {
+		margin-bottom: 0;
+	}
 }


### PR DESCRIPTION
I have removed the margin that WordPress gives to the resizable blocks.