### PR TITLE
Align Support

### DIFF
--- a/block.json
+++ b/block.json
@@ -5,13 +5,14 @@
 	"category": "design",
 	"description": "Block to add empty vertical space (full-width).",
 	"keywords": [
-		"sixa", 
-		"blank", 
-		"divider", 
-		"margin", 
+		"sixa",
+		"blank",
+		"divider",
+		"margin",
 		"separator"
 	],
 	"supports": {
+		"align": [ "wide", "full" ],
 		"anchor": true,
 		"html": false
 	},


### PR DESCRIPTION
Added support for `alignwide` to `alignfull`. This is particularly useful for people that wish to add a background color or gradient to a spacer block and align it to the full width of the page or content.