### PR TITLE
Added schema definition

### DIFF
--- a/block.json
+++ b/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "sixa/spacer",
 	"title": "Spacer",


### PR DESCRIPTION
This PR proposes adding the schema definition to the top `block.json` file to help reduce potential errors in modifying the manifest file during the development by providing tooltips, autocomplete, and validation in supported editors. i.e., VSCode.

Further info can be seen [here](https://make.wordpress.org/systems/2021/11/03/redirects-for-json-schemas/).